### PR TITLE
chore: align license in package.json with repo LICENSE file

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "docs:serve": "npm run docs:build && serve out"
   },
   "author": "RootsID",
-  "license": "ISC",
+  "license": "APACHE 2.0",
   "lint-staged": {
     "src/**/*.{ts,tsx}": [
       "npm run lint",


### PR DESCRIPTION
I noticed the ISC license designated in the package.json yet the LICENSE file says Apache 2.0. This PR fixes that.